### PR TITLE
fix: pytest_plugin for overlays

### DIFF
--- a/lectern/pytest_plugin.py
+++ b/lectern/pytest_plugin.py
@@ -20,9 +20,9 @@ else:
         ignore_name(document.assets)
         ignore_name(document.data)
 
-        for overlay in document.assets.overlays:
+        for overlay in document.assets.overlays.values():
             ignore_name(overlay)
-        for overlay in document.data.overlays:
+        for overlay in document.data.overlays.values():
             ignore_name(overlay)
 
         return document

--- a/lectern/pytest_plugin.py
+++ b/lectern/pytest_plugin.py
@@ -16,8 +16,15 @@ else:
 
     def load_snapshot(path: Path) -> Document:
         document = Document(path=path)
+        
         ignore_name(document.assets)
         ignore_name(document.data)
+
+        for overlay in document.assets.overlays:
+            ignore_name(overlay)
+        for overlay in document.data.overlays:
+            ignore_name(overlay)
+
         return document
 
     class FmtPackText(Fmt[Document]):


### PR DESCRIPTION
Overlays do not get their named ignored when loading via `pytest_insta`